### PR TITLE
Add instructions on granting access to User Capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ Sys.setenv("NOTION_IIS" = "secret_5nLEIYqDd6o58gd1ZAPP4OMH9OnVozyhN9XQysN1nFE")
 ```
 
 Your Notion integration is only aware of the pages and databases that you
-explicitly give it access to. To give your integration access to a page or
+explicitly give it access to. 
+
+- To grant your integration access to **User Capabilities**, navigate to the **Capabilities** page (located below **Secrets**) and select "Read user information including email addresses" within the "User capabilities" subsection.
+- To give your integration access to a page or
 database, go to that page or database, select the three dot icon in the 
 upper-right, click **Add connections**, then find the name of your Notion
 integration and click on it. Your integration (and R) is now able to access
 that page or database.
+
 
 Nosh has three main functions:
 
@@ -43,6 +47,8 @@ library(nosh)
 
 # List all users
 nosh::users()
+# If you get HTTP 403 Forbidden Error,
+# grant your integration access to user capabilities
 
 # List all pages and databases
 nosh::search_all()


### PR DESCRIPTION
During my testing of this package, I encountered the frustrating HTTP 403 Forbidden Error while executing `nosh::users()`. This error occurs because Notion's default selection in the User Capabilities subsection is "No user information":

&nbsp;

<img width="632" alt="Screenshot 2023-05-25 at 10 09 01 PM" src="https://github.com/seankross/nosh/assets/50791792/f76e6730-831f-48c0-a683-65ac9de4f188">

&nbsp;

To address this issue, I added a note in the README, emphasizing the need to grant access to User Capabilities by selecting "Read user information, including email addresses".

Hopefully, new users can avoid encountering the HTTP 403 error.